### PR TITLE
fix: get publications ordering

### DIFF
--- a/src/modules/publications/infra/prisma/repositories/prisma-publication-repository.ts
+++ b/src/modules/publications/infra/prisma/repositories/prisma-publication-repository.ts
@@ -89,7 +89,7 @@ class PrismaPublicationRepository implements PublicationRepository {
         isArchived: typeof isArchived !== undefined ? { equals: isArchived } : undefined,
         authorId: authorId ? { equals: authorId } : undefined,
       },
-      orderBy: orderBy ? [{ [orderBy]: 'asc' }] : undefined,
+      orderBy: orderBy === 'most-recently-created' ? { createdAt: 'desc' } : undefined,
       include: {
         author: true,
         characteristics: true,

--- a/src/modules/publications/repositories/mocks/publication-repository-mock.ts
+++ b/src/modules/publications/repositories/mocks/publication-repository-mock.ts
@@ -74,9 +74,9 @@ class PublicationRepositoryMock implements PublicationRepository {
     );
 
     const publicationsOrderByAndPage = publications
-      .sort((a, b) => {
-        if (orderBy === 'createdAt') {
-          return a.createdAt.getTime() - b.createdAt.getTime();
+      .sort((publication, otherPublication) => {
+        if (orderBy === 'most-recently-created') {
+          return otherPublication.createdAt.getTime() - publication.createdAt.getTime();
         }
         return 0;
       })

--- a/src/modules/publications/repositories/publication-repository.ts
+++ b/src/modules/publications/repositories/publication-repository.ts
@@ -2,15 +2,17 @@ import Publication from '@/modules/publications/entities/publication';
 
 import Image from '../entities/image';
 
+export type OrderBy = 'most-recently-created';
+
 export interface ParametersFindAll {
-  city: string;
-  state: string;
+  city?: string;
+  state?: string;
   categories?: string[];
   isArchived?: boolean;
   authorId?: string;
   page?: number;
   perPage: number;
-  orderBy?: string;
+  orderBy?: OrderBy;
 }
 
 export interface UpdatePublicationData {

--- a/src/modules/publications/use-cases/get-publications/__tests__/get-publications-controller.test.ts
+++ b/src/modules/publications/use-cases/get-publications/__tests__/get-publications-controller.test.ts
@@ -10,7 +10,7 @@ import app from '@/shared/infra/http/app';
 import HTTPResponse from '@/shared/infra/http/models/http-response';
 import prisma from '@/shared/infra/prisma/prisma-client';
 
-import { getNameNumberList, getNumPublications } from './util';
+import { getNameNumberList } from './util';
 
 describe('Get publications controller', () => {
   const URL = '/publications';
@@ -91,12 +91,11 @@ describe('Get publications controller', () => {
       authorId: '',
       page: 1,
       perPage: 20,
-      orderBy: '',
     });
 
     expect(publicationsResponse.statusCode).toEqual(HTTPResponse.STATUS_CODE.OK);
     expect(publicationsResponse.body).toHaveLength(numPublications.length);
-    expect(getNameNumberList(publicationsResponse.body)).toEqual(numPublications);
+    expect(getNameNumberList(publicationsResponse.body)).toEqual(expect.arrayContaining(numPublications));
   });
 
   it('should return an empty array if the city and state filter does not match', async () => {
@@ -120,7 +119,6 @@ describe('Get publications controller', () => {
       authorId: '',
       page: 1,
       perPage: 20,
-      orderBy: '',
     });
 
     expect(publicationsResponse.statusCode).toEqual(HTTPResponse.STATUS_CODE.OK);
@@ -163,12 +161,11 @@ describe('Get publications controller', () => {
         authorId: '',
         page: 1,
         perPage: 20,
-        orderBy: '',
       });
 
     expect(publicationsResponse.statusCode).toEqual(HTTPResponse.STATUS_CODE.OK);
     expect(publicationsResponse.body).toHaveLength(numPublications.length);
-    expect(getNameNumberList(publicationsResponse.body)).toEqual(numPublications);
+    expect(getNameNumberList(publicationsResponse.body)).toEqual(expect.arrayContaining(numPublications));
   });
 
   it('should be able to get the publications by filtering by city and state and isArchived', async () => {
@@ -204,7 +201,6 @@ describe('Get publications controller', () => {
       authorId: '',
       page: 1,
       perPage: 20,
-      orderBy: '',
     });
 
     const publicationsIsArchivedFalseResponse = await request(app).get(URL).query({
@@ -215,15 +211,16 @@ describe('Get publications controller', () => {
       authorId: '',
       page: 1,
       perPage: 20,
-      orderBy: '',
     });
 
     expect(publicationsIsArchivedTrueResponse.statusCode).toEqual(HTTPResponse.STATUS_CODE.OK);
     expect(publicationsIsArchivedTrueResponse.body).toHaveLength(numPublications.length);
-    expect(getNameNumberList(publicationsIsArchivedTrueResponse.body)).toEqual(numPublications);
+    expect(getNameNumberList(publicationsIsArchivedTrueResponse.body)).toEqual(expect.arrayContaining(numPublications));
     expect(publicationsIsArchivedFalseResponse.statusCode).toEqual(HTTPResponse.STATUS_CODE.OK);
     expect(publicationsIsArchivedFalseResponse.body).toHaveLength(numPublicationsOther.length);
-    expect(getNameNumberList(publicationsIsArchivedFalseResponse.body)).toEqual(numPublicationsOther);
+    expect(getNameNumberList(publicationsIsArchivedFalseResponse.body)).toEqual(
+      expect.arrayContaining(numPublicationsOther),
+    );
   });
 
   it('should be able to get the publications by filtering by city and state and authorId', async () => {
@@ -276,12 +273,11 @@ describe('Get publications controller', () => {
       authorId: otherUser.id,
       page: 1,
       perPage: 20,
-      orderBy: '',
     });
 
     expect(publications.statusCode).toEqual(HTTPResponse.STATUS_CODE.OK);
     expect(publications.body).toHaveLength(numPublications.length);
-    expect(getNameNumberList(publications.body)).toEqual(numPublications);
+    expect(getNameNumberList(publications.body)).toEqual(expect.arrayContaining(numPublications));
   });
 
   it('should be able to get the publications by filtering by city and state using pagination', async () => {
@@ -327,7 +323,7 @@ describe('Get publications controller', () => {
       authorId: '',
       page,
       perPage,
-      orderBy: 'name',
+      orderBy: 'most-recently-created',
     });
 
     const publicationsPage2Response = await request(app)
@@ -340,7 +336,7 @@ describe('Get publications controller', () => {
         authorId: '',
         page: page + 1,
         perPage,
-        orderBy: 'name',
+        orderBy: 'most-recently-created',
       });
 
     const publicationsPage4Response = await request(app)
@@ -353,7 +349,7 @@ describe('Get publications controller', () => {
         authorId: '',
         page: page + 3,
         perPage,
-        orderBy: 'name',
+        orderBy: 'most-recently-created',
       });
 
     const publicationsPage15Response = await request(app)
@@ -366,15 +362,15 @@ describe('Get publications controller', () => {
         authorId: '',
         page: page + 14,
         perPage,
-        orderBy: 'name',
+        orderBy: 'most-recently-created',
       });
 
     expect(publicationsPage1Response.statusCode).toEqual(HTTPResponse.STATUS_CODE.OK);
-    expect(getNameNumberList(publicationsPage1Response.body)).toEqual(getNumPublications(perPage, page));
+    expect(getNameNumberList(publicationsPage1Response.body)).toEqual([24, 23, 22, 21, 20]);
     expect(publicationsPage2Response.statusCode).toEqual(HTTPResponse.STATUS_CODE.OK);
-    expect(getNameNumberList(publicationsPage2Response.body)).toEqual(getNumPublications(perPage, page + 1));
+    expect(getNameNumberList(publicationsPage2Response.body)).toEqual([19, 18, 17, 16, 15]);
     expect(publicationsPage4Response.statusCode).toEqual(HTTPResponse.STATUS_CODE.OK);
-    expect(getNameNumberList(publicationsPage4Response.body)).toEqual(getNumPublications(perPage, page + 3));
+    expect(getNameNumberList(publicationsPage4Response.body)).toEqual([9, 8, 7, 6, 5]);
     expect(publicationsPage15Response.statusCode).toEqual(HTTPResponse.STATUS_CODE.OK);
     expect(publicationsPage15Response.body).toHaveLength(0);
     expect(publicationsPage15Response.body).toEqual([]);
@@ -407,7 +403,7 @@ describe('Get publications controller', () => {
       authorId: '',
       page: 1,
       perPage,
-      orderBy: 'name',
+      orderBy: 'most-recently-created',
     });
 
     expect(publicationsOrderByNameResponse.statusCode).toEqual(HTTPResponse.STATUS_CODE.OK);
@@ -437,7 +433,6 @@ describe('Get publications controller', () => {
       authorId: '',
       page: 1,
       perPage: totalPublications,
-      orderBy: '',
     });
 
     expect(publicationsResponse.statusCode).toEqual(HTTPResponse.STATUS_CODE.OK);
@@ -469,7 +464,6 @@ describe('Get publications controller', () => {
       authorId: '',
       page: 1,
       perPage: totalPublications,
-      orderBy: '',
     });
 
     expect(publicationsResponse.statusCode).toEqual(HTTPResponse.STATUS_CODE.OK);

--- a/src/modules/publications/use-cases/get-publications/__tests__/get-publications-use-case.test.ts
+++ b/src/modules/publications/use-cases/get-publications/__tests__/get-publications-use-case.test.ts
@@ -66,7 +66,6 @@ describe('Get publications use case', () => {
       authorId: '',
       page: 1,
       perPage: 20,
-      orderBy: '',
     });
 
     expect(publications).toHaveLength(numPublications.length);
@@ -86,7 +85,6 @@ describe('Get publications use case', () => {
       authorId: '',
       page: 1,
       perPage: 20,
-      orderBy: '',
     });
 
     expect(publications).toHaveLength(0);
@@ -118,7 +116,6 @@ describe('Get publications use case', () => {
       authorId: '',
       page: 1,
       perPage: 20,
-      orderBy: '',
     });
 
     expect(publications).toHaveLength(numPublications.length);
@@ -147,7 +144,6 @@ describe('Get publications use case', () => {
       authorId: '',
       page: 1,
       perPage: 20,
-      orderBy: '',
     });
 
     const publicationsIsArchivedFalse = await useCase.execute({
@@ -158,7 +154,6 @@ describe('Get publications use case', () => {
       authorId: '',
       page: 1,
       perPage: 20,
-      orderBy: '',
     });
 
     expect(publicationsIsArchivedTrue).toHaveLength(numPublications.length);
@@ -198,7 +193,6 @@ describe('Get publications use case', () => {
       authorId: otherUser.id,
       page: 1,
       perPage: 20,
-      orderBy: '',
     });
 
     expect(publications).toHaveLength(numPublications.length);
@@ -222,7 +216,6 @@ describe('Get publications use case', () => {
       authorId: '',
       page,
       perPage,
-      orderBy: '',
     });
 
     const publicationsPage2 = await useCase.execute({
@@ -233,7 +226,6 @@ describe('Get publications use case', () => {
       authorId: '',
       page: page + 1,
       perPage,
-      orderBy: '',
     });
 
     const publicationsPage4 = await useCase.execute({
@@ -244,7 +236,6 @@ describe('Get publications use case', () => {
       authorId: '',
       page: page + 3,
       perPage,
-      orderBy: '',
     });
 
     const publicationsPage15 = await useCase.execute({
@@ -255,7 +246,6 @@ describe('Get publications use case', () => {
       authorId: '',
       page: page + 14,
       perPage,
-      orderBy: '',
     });
 
     expect(publicationsPage1).toHaveLength(perPage);
@@ -269,7 +259,7 @@ describe('Get publications use case', () => {
   });
 
   it('should get the publications by filtering by city and state and sorting by creatdAt', async () => {
-    const numPublications = [2, 3, 4, 8];
+    const numPublications = [3, 2, 1, 0];
 
     for (let i = 0; i < 20; i++) {
       const modifyPublication = { ...publication, name: `publication_${i}` };
@@ -290,9 +280,9 @@ describe('Get publications use case', () => {
       categories: '',
       isArchived: false,
       authorId: '',
-      page: 5,
+      page: 0,
       perPage: 4,
-      orderBy: 'createdAt',
+      orderBy: 'most-recently-created',
     });
 
     expect(publications).toHaveLength(numPublications.length);
@@ -316,7 +306,7 @@ describe('Get publications use case', () => {
       authorId: '',
       page: 1,
       perPage: totalPublications,
-      orderBy: 'createdAt',
+      orderBy: 'most-recently-created',
     });
 
     expect(publications).toHaveLength(5);
@@ -342,7 +332,7 @@ describe('Get publications use case', () => {
       authorId: '',
       page: 1,
       perPage: totalPublications,
-      orderBy: 'createdAt',
+      orderBy: 'most-recently-created',
     });
 
     expect(publications).toHaveLength(5);

--- a/src/modules/publications/use-cases/get-publications/__tests__/util.ts
+++ b/src/modules/publications/use-cases/get-publications/__tests__/util.ts
@@ -1,11 +1,11 @@
 import Publication from '@/modules/publications/entities/publication';
 
 export function getNameNumberList(publications: Publication[]) {
-  return publications.map((publication: Publication) => parseInt(publication.name.split('_')[1])).sort();
+  return publications.map((publication: Publication) => parseInt(publication.name.split('_')[1]));
 }
 
 export function getNumPublications(perPage: number, page: number): number[] {
-  return [...Array(perPage * page).keys()].splice(perPage * (page - 1), perPage).sort();
+  return [...Array(perPage * page).keys()].splice(perPage * (page - 1), perPage);
 }
 
 export function addDays(numOfDays: number) {

--- a/src/modules/publications/use-cases/get-publications/get-publications-controller.ts
+++ b/src/modules/publications/use-cases/get-publications/get-publications-controller.ts
@@ -5,6 +5,7 @@ import HTTPResponse from '@/shared/infra/http/models/http-response';
 import UseCaseController from '@/shared/use-cases/use-case-controller';
 
 import Publication from '../../entities/publication';
+import { OrderBy } from '../../repositories/publication-repository';
 import GetPublicationsUseCase from './get-publications-use-case';
 
 class GetPublicationsController implements UseCaseController {
@@ -14,14 +15,14 @@ class GetPublicationsController implements UseCaseController {
     const getPublicationsUseCase = container.resolve(GetPublicationsUseCase);
 
     const publications = await getPublicationsUseCase.execute({
-      city: city as string,
-      state: state as string,
-      categories: categories as string,
+      city: city as string | undefined,
+      state: state as string | undefined,
+      categories: categories as string | undefined,
       isArchived: isArchived === 'true',
-      authorId: authorId as string,
-      page: parseInt(page as string),
-      perPage: parseInt(perPage as string),
-      orderBy: orderBy as string,
+      authorId: authorId as string | undefined,
+      page: page === undefined ? undefined : parseInt(page as string),
+      perPage: perPage === undefined ? undefined : parseInt(perPage as string),
+      orderBy: orderBy as OrderBy | undefined,
     });
 
     const publicationsJson = Publication.manyToJson(publications);

--- a/src/modules/publications/use-cases/get-publications/get-publications-use-case.ts
+++ b/src/modules/publications/use-cases/get-publications/get-publications-use-case.ts
@@ -1,19 +1,19 @@
 import { inject, injectable } from 'tsyringe';
 
 import Publication from '@/modules/publications/entities/publication';
-import PublicationRepository from '@/modules/publications/repositories/publication-repository';
+import PublicationRepository, { OrderBy } from '@/modules/publications/repositories/publication-repository';
 import User from '@/modules/users/entities/user';
 import UseCaseService from '@/shared/use-cases/use-case-service';
 
 interface GetPublicationsRequest {
-  city: string;
-  state: string;
+  city?: string;
+  state?: string;
   categories?: string;
   isArchived?: boolean;
   authorId?: string;
   page?: number;
-  perPage: number;
-  orderBy?: string;
+  perPage?: number;
+  orderBy?: OrderBy;
 }
 
 @injectable()


### PR DESCRIPTION
### Fixes
- Changed the ordering strategy from `createdAt` to `most-recently-created`, so that the frontend can get the most recent publications to list.
