### PR TITLE
fix: authorization to get publications by id

### DIFF
--- a/src/shared/infra/http/routes/publication-router.ts
+++ b/src/shared/infra/http/routes/publication-router.ts
@@ -23,7 +23,7 @@ const getPublicationsController = new GetPublicationsController();
 publicationRouter.get('/', getPublicationsController.handle);
 
 const getPublicationController = new GetPublicationController();
-publicationRouter.get('/:id', ensureAuthenticated, getPublicationController.handle);
+publicationRouter.get('/:id', getPublicationController.handle);
 
 const updatePublicationController = new UpdatePublicationController();
 publicationRouter.patch('/:id', ensureAuthenticated, updatePublicationController.handle);

--- a/src/shared/infra/http/routes/user-router.ts
+++ b/src/shared/infra/http/routes/user-router.ts
@@ -15,6 +15,7 @@ userRouter.post('/', createUserController.handle);
 
 const updateUserPasswordController = new UpdateUserPasswordController();
 userRouter.patch('/:id/password', ensureAuthenticated, ensureConfirmUser, updateUserPasswordController.handle);
+
 const getUserController = new GetUserController();
 userRouter.get('/:id', ensureAuthenticated, ensureConfirmUser, getUserController.handle);
 


### PR DESCRIPTION
### Fixes
- Allowed unauthenticated users to get publications by id, as there should be no authentication restrictions to see their details.
